### PR TITLE
Copy over templates from other repositories

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+---
+name: Bug report
+about: Report a problem/bug to help us improve
+
+---
+
+**Description of the problem**
+
+<!--
+Please be as detailed as you can when describing an issue. The more information
+we have, the easier it will be for us to track this down.
+-->
+
+
+
+**Full code that generated the error**
+
+<!--
+Include any data files or inputs required to run the code. It really helps if
+we can run the code on our own machines.
+-->
+
+```python
+PASTE YOUR CODE HERE
+```
+
+
+**Full error message**
+
+```
+PASTE ERROR MESSAGE HERE
+```
+
+
+
+**System information**
+
+* Operating system:
+* Python installation (Anaconda, system, ETS):
+* Version of Python:
+* Version of this package:
+* If using conda, paste the output of `conda list` below:
+
+<details>
+<summary>output of conda list</summary>
+<pre>
+
+PASTE OUTPUT OF CONDA LIST HERE
+
+</pre>
+</details>

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Request the addition of a new feature/functionality
+
+---
+
+**Description of the desired feature**
+
+<!--
+Please be as detailed as you can in your description. If possible, include an
+example of how you would like to use this feature (even better if it's a code
+example).
+-->
+
+
+
+**Are you willing to help implement and maintain this feature?** Yes/No
+
+<!--
+Every feature we add is code that we will have to maintain and keep updated.
+This takes a lot of effort. If you are willing to be involved in the project
+and help maintain your feature, it will make it easier for us to accept it.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+Please describe changes proposed and WHY you made them. If fixing an issue,
+include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
+automatically close it when this gets merged.
+-->
+
+
+
+
+
+**Reminders**:
+
+- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
+- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
+- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
+- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
+- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,26 @@
+# Configuration for welcome bot - https://github.com/behaviorbot/welcome
+########################################################################################
+# Comment to be posted to on first time issues
+newIssueWelcomeComment: |
+  👋 Thanks for opening your first issue here! **Please make sure you filled out the template with as much detail as possible.**
+
+  You might also want to take a look at our [Contributing Guide](https://github.com/fatiando/contributing/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/fatiando/contributing/blob/master/CODE_OF_CONDUCT.md).
+
+# Comment to be posted to on PRs from first time contributors in your repository
+newPRWelcomeComment: |
+  💖 Thanks for opening this pull request! 💖
+
+  Please make sure you read our [Contributing Guide](https://github.com/fatiando/contributing/blob/master/CONTRIBUTING.md) and abide by our [Code of Conduct](https://github.com/fatiando/contributing/blob/master/CODE_OF_CONDUCT.md).
+
+  A few things to keep in mind:
+
+  * Remember to run ``make format`` to make sure your code follows our style guide.
+  * If you need help writing tests, take a look at the existing ones for inspiration. If you don't know where to start, let us know and we'll walk you through it.
+  * All new features should be documented. It helps to write the docstrings for your functions/classes before writing the code. This will help you think about your code design and results in better code.
+  * No matter what, we are really grateful that you put in the effort to do this! ⭐
+
+# Comment to be posted to on pull requests merged by a first time user
+firstPRMergeComment: |
+  🎉🎉🎉 Congrats on merging your first pull request and welcome to the team! 🎉🎉🎉
+
+  Please open a new pull request to add yourself to the `AUTHORS.md` file. We hope that this was a good experience for you. Let us know if there is any way that the contributing process could be improved.


### PR DESCRIPTION
Moved the templates here and adapt them to be independent of the
repository. Links to community files are to `fatiando/contributing`.
Cleaned up the comments with instructions on the templates.