### PR TITLE
Add instruction to build the docs before creating the release PR

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -36,6 +36,7 @@ assignees: ''
 - [ ] Copy the changes to `doc/changes.rst`
 - [ ] Make a Markdown copy of the changelog: `pandoc -s changes.rst -o changes.md --wrap=none`
 - [ ] Add a link to the new release version documentation in `README.rst`
+- [ ] Build and serve the docs locally with `make -C doc all serve` to check if the changelog looks well
 - [ ] Open a PR to update the changelog
 - [ ] Merge the PR
 


### PR DESCRIPTION
Add and additional checkbox before creating the changelog PR to instruct on build and locally serve the docs in order to check they look well.