### PR TITLE
Remove "Description" heading from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,20 @@
+
+
 <!--
-Thank you for contributing a pull request! Please ensure you have taken a look 
-at the CONTRIBUTING.md file in this repository (if available) and the general 
-guidelines at https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
+Thank you for contributing a pull request to Fatiando! 💖
+
+👆🏽 ABOVE: Describe the changes proposed and WHY you made them.
+
+👇🏽 BELOW: Link to any relevant issue or pull request.
+
+Please ensure you have taken a look at the CONTRIBUTING.md file 
+in this repository (if available) and the general guidelines at 
+https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
 -->
-**Description**
+
+**Relevant issues/PRs:**
 <!--
-Please describe changes proposed and WHY you made them.
--->
-
-
-
-**Relevant issues/PRs**
-<!--
-Link to relevant issues/PRs. Example: "Fixes #1234" or "See also #345"
+Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
 Use keywords (e.g., Fixes, Closes) to create the links and automatically
 close issues when this PR is merged. 
 See https://github.com/blog/1506-closing-issues-via-pull-requests


### PR DESCRIPTION
When a PR is made with a single commit, the commit message is included at 
the top of the PR description. With our template, we had to copy that below
the "Description" heading, which was very annoying. This new template asks
for a description above and no heading, which eliminates that.

<!--
Thank you for contributing a pull request! Please ensure you have taken a look 
at the CONTRIBUTING.md file in this repository (if available) and the general 
guidelines at https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->



**Relevant issues/PRs**
<!--
Link to relevant issues/PRs. Example: "Fixes #1234" or "See also #345"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
