### PR TITLE
Add item to check if PROJECT placeholder was replaced

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -32,6 +32,7 @@ assignees: ''
 - [ ] Add a list of people who contributed to the release: `git shortlog HEAD...v1.2.3 -sne`
 - [ ] Add the release date and Zenodo DOI badge to the top
 - [ ] Replace the PR numbers with links: ``sed --in-place "s,#\([0-9]\+\),\`#\1 <https://github.com/fatiando/PROJECT/pull/\1>\`__,g" changes.rst``
+- [ ] Check that you changed the ``PROJECT`` placeholder when running the last command.
 - [ ] Copy the changes to `doc/changes.rst`
 - [ ] Make a Markdown copy of the changelog: `pandoc -s changes.rst -o changes.md --wrap=none`
 - [ ] Add a link to the new release version documentation in `README.rst` and `doc/versions.rst` (if the file exists).


### PR DESCRIPTION
Add a new item to the release checklist to ensure that the `PROJECT`
placeholder was replaced by the name of the package we are releasing.

**Relevant issues/PRs:**

Inspired by https://github.com/fatiando/harmonica/pull/342
